### PR TITLE
Feature/remove hacky clipboard

### DIFF
--- a/longtest.js
+++ b/longtest.js
@@ -1,7 +1,50 @@
 import 'src/edit'
+
+
+
 flishdflkasdfstingfunctiont estinghoee
+asdfstingfunctiont estinghoee
+flishdflkasdfstingfunctiont estinghoee
+flishdflka
+asdfstingfunctiont estinghoee
+flishdflkasdfstingfunctiont estinghoee
+flishdflksdfstingfunctiont estinghoee
+flishdflka
+flishdflksdfstingfunctiont estinghoee
+flishdflkasdfstingfunctiont estinghoee
+flishdflkasdfstingfunctiont estinghoee
+flishdflkasdfstingfunctiont estinghoee
+flishdflkasdfstingfunctiont estinghoee
+flishdflkasdfstingfunctiont estinghoee
+flishdflkasdfstingfunctiont estinghoee
+flishdflkasdfstingfunctiont estinghoee
+f
+l
+ishdflkasdfstingfunctiont estinghoee
+flishdflkasdfstingfunctiont estinghoee
+flishdflkasdfstingfunctiont estinghoee
+flishdflkasdfstingfunctiont estinghoee
+
+
+flishdflkasdfstingfunctiont estinghoee
+
+flishdflkasdfstingfunctiont estinghoee
+
+flishdflkasdfstingfunctiont estinghoeeflishdflkasdfstingfunctiont estinghoee
+
+flishdflkasdfstingfunctiont estinghoee
+
+flishdflkasdfstingfunctiont estinghoeeflishdflkasdfstingfunctiont estinghoee
 'take the last season 1' how are you
+
+
 '// 'take t//he last season 1\' how are you' take me out
+
+'// 'take t//he last season 1\' how are you' take me out
+
+'// 'take t//he last season 1\' how are you' take me out
+
+'// 'take t//he last season 1\' how are you' take me out'// 'take t//he last season 1\' how are you' take me out
 // 'take the last season 1\' how are you' take me out
 
 

--- a/longtest.js
+++ b/longtest.js
@@ -3,9 +3,14 @@ import 'src/edit'
 
 import 'src/edit'
 
-https://www.youtube.com/watch?v=xsOh6hS6mek&list=RD3lBBxYQUVrc&index=7https://www.youtube.com/watch?v=xsOh6hS6mek&list=RD3lBBxYQUVrc&index=7https://www.youtube.com/watch?v=xsOh6hS6mek&list=RD3lBBxYQUVrc&index=7
 ehttps://www.youtube.com/watch?v=xsOh6hS6mek&list=RD3lBBxYQUVrc&index=7 last season 1\' how are you' take me out
 https://www.youtube.com/watch?v=xsOh6hS6mek&list=RD3lBBxYQUVrc&index=7
+e last season 1\' how are you' take me out
+e last season 1\' how are you' take me out
+e last season 1\' how are you' take me out
+e last season 1\' how are you' take me out
+e las are you'  take me out are you take me out are youtake me out are you' take me out
+e last season 1\' how are you' take me out
 e last season 1\' how are you' take me out
 e last season 1\' how are you' take me out
 e last season 1\' how are you' take me out

--- a/longtest.js
+++ b/longtest.js
@@ -3,21 +3,33 @@ import 'src/edit'
 
 
 flishdflkasdfstingfunctiont estinghoee
+
 asdfstingfunctiont estinghoee
 flishdflkasdfstingfunctiont estinghoee
 flishdflka
 asdfstingfunctiont estinghoee
 flishdflkasdfstingfunctiont estinghoee
 flishdflksdfstingfunctiont estinghoee
-flishdflka
+
+ingfunctiont estinghoee
+flishdflkasdfstingfunctiont estinghoee
+flishdflkasdfstingfunctiont estinghoee
+flishdfl
+lksdfst
+flishdflkasdfstingfunctiont estinghoee
+flishdflkasdfstingfunctiont estinghoee
+flishdfl
+lksdfstingfunctiont estinghoee
+flishdflkasdfstingfunctiont estinghoee
+flishdflkasdfstingfunctiont estinghoee
+flishdfl
 flishdflksdfstingfunctiont estinghoee
 flishdflkasdfstingfunctiont estinghoee
 flishdflkasdfstingfunctiont estinghoee
-flishdflkasdfstingfunctiont estinghoee
-flishdflkasdfstingfunctiont estinghoee
-flishdflkasdfstingfunctiont estinghoee
-flishdflkasdfstingfunctiont estinghoee
-flishdflkasdfstingfunctiont estinghoee
+flishdflkasdfstingiont estinghoee
+flishdflkasdfstingtiont estinghoee
+flishdf
+flishdlkasdfstingfunctiont estinghoee
 f
 l
 ishdflkasdfstingfunctiont estinghoee

--- a/longtest.js
+++ b/longtest.js
@@ -3,13 +3,35 @@ import 'src/edit'
 
 import 'src/edit'
 
+e last season 1\' how are you' take me out
 '// 'take t//he last season 1\' how are you' take me out
-
 '// 'take t//he last season 1\' how are you' take me out
-
+'// 'take t//he
+'// 'tt season 1\' how are you' take me out
 '// 'take t//he last season 1\' how are you' take me out
-
-'// 'take t//he last season 1\' how are you' take me out'// 'take t//he last season 1\' how are you' take me out
+'// 'take t//he last season 1\' how are you' take me out
+'// 'take t//he
+'// 'tt season 1\' how are you' take me out
+'// 'take t//he last season 1\' how are you' take me out
+'// 'take t//he last season 1\' how are you' take me out
+'// 'take t//he
+'// 'tt season 1\' how are you' take me out
+'// 'take t//he last season 1\' how are you' take me out
+'// 'take t//he last season 1\' how are you' take me out
+'// 'take t//he
+'// 'tt season 1\' how are you' take me out
+'// 'take t//he last season 1\' how are you' take me out
+'// 'take t//he last season 1\' how are you' take me out
+'// 'take t//he
+'// 'tt season 1\' how are you' take me out
+'// 'take t//he last season 1\' how are you' take me out
+'// 'take t//he last season 1\' how are you' take me out
+'// 'take t//he
+'// 'tt season 1\' how are you' take me out
+'// 'take t//he last season 1\' how are you' take me out
+'// 'take t//he last season 1\' how are you' take me out
+'// 'take t//he
+'// 'take t//h last season 1\' how are you' take me out'// 'take t//he last season 1\' how are you' take me out
 // 'take the last season 1\' how are you' take me out
 
 

--- a/longtest.js
+++ b/longtest.js
@@ -1,54 +1,7 @@
 import 'src/edit'
+import 'src/edit'
 
-
-
-flishdflkasdfstingfunctiont estinghoee
-
-asdfstingfunctiont estinghoee
-flishdflkasdfstingfunctiont estinghoee
-flishdflka
-asdfstingfunctiont estinghoee
-flishdflkasdfstingfunctiont estinghoee
-flishdflksdfstingfunctiont estinghoee
-
-ingfunctiont estinghoee
-flishdflkasdfstingfunctiont estinghoee
-flishdflkasdfstingfunctiont estinghoee
-flishdfl
-lksdfst
-flishdflkasdfstingfunctiont estinghoee
-flishdflkasdfstingfunctiont estinghoee
-flishdfl
-lksdfstingfunctiont estinghoee
-flishdflkasdfstingfunctiont estinghoee
-flishdflkasdfstingfunctiont estinghoee
-flishdfl
-flishdflksdfstingfunctiont estinghoee
-flishdflkasdfstingfunctiont estinghoee
-flishdflkasdfstingfunctiont estinghoee
-flishdflkasdfstingiont estinghoee
-flishdflkasdfstingtiont estinghoee
-flishdf
-flishdlkasdfstingfunctiont estinghoee
-f
-l
-ishdflkasdfstingfunctiont estinghoee
-flishdflkasdfstingfunctiont estinghoee
-flishdflkasdfstingfunctiont estinghoee
-flishdflkasdfstingfunctiont estinghoee
-
-
-flishdflkasdfstingfunctiont estinghoee
-
-flishdflkasdfstingfunctiont estinghoee
-
-flishdflkasdfstingfunctiont estinghoeeflishdflkasdfstingfunctiont estinghoee
-
-flishdflkasdfstingfunctiont estinghoee
-
-flishdflkasdfstingfunctiont estinghoeeflishdflkasdfstingfunctiont estinghoee
-'take the last season 1' how are you
-
+import 'src/edit'
 
 '// 'take t//he last season 1\' how are you' take me out
 

--- a/longtest.js
+++ b/longtest.js
@@ -3,6 +3,13 @@ import 'src/edit'
 
 import 'src/edit'
 
+https://www.youtube.com/watch?v=xsOh6hS6mek&list=RD3lBBxYQUVrc&index=7https://www.youtube.com/watch?v=xsOh6hS6mek&list=RD3lBBxYQUVrc&index=7https://www.youtube.com/watch?v=xsOh6hS6mek&list=RD3lBBxYQUVrc&index=7
+ehttps://www.youtube.com/watch?v=xsOh6hS6mek&list=RD3lBBxYQUVrc&index=7 last season 1\' how are you' take me out
+https://www.youtube.com/watch?v=xsOh6hS6mek&list=RD3lBBxYQUVrc&index=7
+e last season 1\' how are you' take me out
+e last season 1\' how are you' take me out
+e last season 1\' how are you' take me out
+e last season 1\' how are you' take me out
 e last season 1\' how are you' take me out
 '// 'take t//he last season 1\' how are you' take me out
 '// 'take t//he last season 1\' how are you' take me out

--- a/src/edit.js
+++ b/src/edit.js
@@ -32,7 +32,6 @@ const state = {
     mode: 'n',
     clipboard: [],
     clipboardVisualBlock: false,
-    clipboardNewLine: true,
     searchQuery: '',
     searching: false,
     replaceQuery: '',

--- a/src/edit.js
+++ b/src/edit.js
@@ -30,7 +30,6 @@ const state = {
     allowCommandLogging: false,
     vim: process.argv[2] !== '-n',
     mode: 'n',
-    clipboard: [],
     clipboardVisualBlock: false,
     searchQuery: '',
     searching: false,

--- a/src/keybinds/searchKeys.js
+++ b/src/keybinds/searchKeys.js
@@ -29,6 +29,7 @@ function handleSearchKeys(key, state, screen) {
                 state.replaceQuery = state.searchQuery.substring(0, state.searchQuery.length - 1);
             }
         }
+        logCommand(false, state, key);
     } else {
         if (isWritable(key)) {
             state.searchQuery += key;
@@ -49,7 +50,6 @@ function handleSearchKeys(key, state, screen) {
             }
         }
     }
-    logCommand(false, state, key);
     renderScreen(state, screen);
 }
 

--- a/src/keybinds/vimKeys.js
+++ b/src/keybinds/vimKeys.js
@@ -296,7 +296,6 @@ function handleVimKeys(key, state, screen) {
         if (key === 'w') {
             const { beginning, end } = getCoorsInsideWord(state);
             copyInsideAreaSameLine(state, beginning, end);
-
         } else if (key === 'f') {
             const { beginning, end } = getInsideOfIndentLevel(state);
             state.visualLine.row = beginning;

--- a/src/keybinds/vimKeys.js
+++ b/src/keybinds/vimKeys.js
@@ -829,7 +829,6 @@ function handleVimKeys(key, state, screen) {
             state.searchQuery = '';
             state.search.row = state.row;
             state.search.col = state.col;
-            logCommand(true, state, key);
         } else if (key === 'v') {
             state.mode = 'v';
             state.visual = {

--- a/src/keybinds/vimKeys.js
+++ b/src/keybinds/vimKeys.js
@@ -74,19 +74,19 @@ function handleVimKeys(key, state, screen) {
     } else if (state.previousKeys === 'd') {
         if (key === 'w') {
             const endOfWord = getCoorForwardWord(state);
-            copyToClipboard(state, [state.data[state.row].substring(state.col, endOfWord)], false);
+            copyToClipboard(state, [state.data[state.row].substring(state.col, endOfWord)]);
             state.data[state.row] = state.data[state.row].substring(0, state.col) + state.data[state.row].substring(endOfWord);
             state.previousKeys = '';
             logCommand(false, state, key);
             createSnapshot(state);
             renderScreen(state, screen);
         } else if (key === 'j') {
-            const newClipboard = [];
+            const newClipboard = ['\n'];
             newClipboard.push(state.data[state.row]);
             if (state.data[state.row + 1] !== undefined) {
                 newClipboard.push(state.data[state.row + 1]);
             }
-            copyToClipboard(state, newClipboard, true);
+            copyToClipboard(state, newClipboard);
             state.data.splice(state.row, 1);
             state.data.splice(state.row, 1);
             if (state.row > state.data.length - 1) {
@@ -101,12 +101,12 @@ function handleVimKeys(key, state, screen) {
             createSnapshot(state);
             renderScreen(state, screen);
         } else if (key === 'k') {
-            const newClipboard = [];
+            const newClipboard = ['\n'];
             if (state.data[state.row - 1] !== undefined) {
                 newClipboard.push(state.data[state.row - 1]);
             }
             newClipboard.push(state.data[state.row]);
-            copyToClipboard(state, newClipboard, true);
+            copyToClipboard(state, newClipboard);
             state.data.splice(state.row, 1);
             if (state.data[state.row - 1] !== undefined) {
                 state.data.splice(state.row - 1, 1);
@@ -124,7 +124,7 @@ function handleVimKeys(key, state, screen) {
             state.previousKeys += key;
             logCommand(false, state, key);
         } else if (key === 'd') {
-            copyToClipboard(state, [state.data[state.row]], true);
+            copyToClipboard(state, ['\n', state.data[state.row]]);
             state.data.splice(state.row, 1);
             state.col = firstNonSpace(state, state.row);
             if (state.row > state.data.length - 1) {
@@ -189,7 +189,7 @@ function handleVimKeys(key, state, screen) {
     } else if (state.previousKeys === 'di') {
         if (key === 'w') {
             const { beginning, end } = getCoorsInsideWord(state);
-            copyToClipboard(state, [state.data[state.row].substring(beginning + 1, end)], false);
+            copyToClipboard(state, [state.data[state.row].substring(beginning + 1, end)]);
             removeInsideAreaSameLine(state, beginning, end, 'n');
             logCommand(false, state, key);
             createSnapshot(state);
@@ -199,11 +199,11 @@ function handleVimKeys(key, state, screen) {
             state.visualLine.row = beginning;
             state.row = end;
             state.col = 0;
-            const newClipboard = [];
+            const newClipboard = ['\n'];
             for (let i = state.visualLine.row; i <= state.row; i += 1) {
                 newClipboard.push(state.data[i]);
             }
-            copyToClipboard(state, newClipboard, true);
+            copyToClipboard(state, newClipboard);
             state.data.splice(state.visualLine.row, state.row - state.visualLine.row + 1);
             state.row = state.visualLine.row;
             if (state.row > state.data.length - 1) {
@@ -218,35 +218,35 @@ function handleVimKeys(key, state, screen) {
             renderScreen(state, screen);
         } else if (key === '[' || key === ']' || key === 'd') {
             const { beginning, end } = getCoorsInsideCharDiff(state, '[', ']');
-            copyToClipboard(state, [state.data[state.row].substring(beginning + 1, end)], false);
+            copyToClipboard(state, [state.data[state.row].substring(beginning + 1, end)]);
             removeInsideAreaSameLine(state, beginning, end, 'n');
             logCommand(false, state, key);
             createSnapshot(state);
             renderScreen(state, screen);
         } else if (key === '<' || key === '>' || key === 't') {
             const { beginning, end } = getCoorsInsideCharDiff(state, '<', '>');
-            copyToClipboard(state, [state.data[state.row].substring(beginning + 1, end)], false);
+            copyToClipboard(state, [state.data[state.row].substring(beginning + 1, end)]);
             removeInsideAreaSameLine(state, beginning, end, 'n');
             logCommand(false, state, key);
             createSnapshot(state);
             renderScreen(state, screen);
         } else if (key === '(' || key === ')' || key === 'b') {
             const { beginning, end } = getCoorsInsideCharDiff(state, '(', ')');
-            copyToClipboard(state, [state.data[state.row].substring(beginning + 1, end)], false);
+            copyToClipboard(state, [state.data[state.row].substring(beginning + 1, end)]);
             removeInsideAreaSameLine(state, beginning, end, 'n');
             logCommand(false, state, key);
             createSnapshot(state);
             renderScreen(state, screen);
         } else if (key === '{' || key === '}' || key === 'B') {
             const { beginning, end } = getCoorsInsideCharDiff(state, '{', '}');
-            copyToClipboard(state, [state.data[state.row].substring(beginning + 1, end)], false);
+            copyToClipboard(state, [state.data[state.row].substring(beginning + 1, end)]);
             removeInsideAreaSameLine(state, beginning, end, 'n');
             logCommand(false, state, key);
             createSnapshot(state);
             renderScreen(state, screen);
         } else if (key === '\'' || key === '"' || key === '`') {
             const { beginning, end } = getCoorsInsideCharSame(state, key);
-            copyToClipboard(state, [state.data[state.row].substring(beginning + 1, end)], false);
+            copyToClipboard(state, [state.data[state.row].substring(beginning + 1, end)]);
             removeInsideAreaSameLine(state, beginning, end, 'n');
             logCommand(false, state, key);
             createSnapshot(state);
@@ -301,11 +301,11 @@ function handleVimKeys(key, state, screen) {
             state.visualLine.row = beginning;
             state.row = end;
             state.col = 0;
-            const newClipboard = [];
+            const newClipboard = ['\n'];
             for (let i = state.visualLine.row; i <= state.row; i += 1) {
                 newClipboard.push(state.data[i]);
             }
-            copyToClipboard(state, newClipboard, true);
+            copyToClipboard(state, newClipboard);
             state.row = state.visualLine.row;
             firstNonSpace(state, state.row);
             renderScreen(state, screen);
@@ -333,25 +333,25 @@ function handleVimKeys(key, state, screen) {
         state.previousKeys = '';
     } else if (state.previousKeys === 'y') {
         if (key === 'j') {
-            const newClipboard = [];
+            const newClipboard = ['\n'];
             newClipboard.push(state.data[state.row]);
             if (state.data[state.row + 1]) {
                 newClipboard.push(state.data[state.row + 1]);
             }
-            copyToClipboard(state, newClipboard, true);
+            copyToClipboard(state, newClipboard);
             logCommand(false, state, key);
             state.previousKeys = '';
         } else if (key === 'k') {
-            const newClipboard = [];
+            const newClipboard = ['\n'];
             if (state.data[state.row - 1]) {
                 newClipboard.push(state.data[state.row - 1]);
             }
             newClipboard.push(state.data[state.row]);
-            copyToClipboard(state, newClipboard, true);
+            copyToClipboard(state, newClipboard);
             logCommand(false, state, key);
             state.previousKeys = '';
         } else if (key === 'y') {
-            copyToClipboard(state, [state.data[state.row]], true);
+            copyToClipboard(state, ['\n', state.data[state.row]]);
             logCommand(false, state, key);
             state.previousKeys = '';
         } else if (key === 'i' || key === 'f' || key === 'F' || key === 't' || key === 'T') {
@@ -414,12 +414,12 @@ function handleVimKeys(key, state, screen) {
             state.previousKeys += key;
             logCommand(false, state, key);
         } else if (key === 'j') {
-            const newClipboard = [];
+            const newClipboard = ['\n'];
             newClipboard.push(state.data[state.row]);
             if (state.data[state.row + 1]) {
                 newClipboard.push(state.data[state.row + 1]);
             }
-            copyToClipboard(state, newClipboard, true);
+            copyToClipboard(state, newClipboard);
             state.data.splice(state.row, 1);
             state.data.splice(state.row, 1);
             if (state.row > state.data.length - 1) {
@@ -434,12 +434,12 @@ function handleVimKeys(key, state, screen) {
             logCommand(false, state, key);
             renderScreen(state, screen);
         } else if (key === 'k') {
-            const newClipboard = [];
+            const newClipboard = ['\n'];
             if (state.data[state.row - 1]) {
                 newClipboard.push(state.data[state.row - 1]);
             }
             newClipboard.push(state.data[state.row]);
-            copyToClipboard(state, newClipboard, true);
+            copyToClipboard(state, newClipboard);
             state.data.splice(state.row, 1);
             if (state.data[state.row - 1]) {
                 state.data.splice(state.row - 1, 1);
@@ -455,7 +455,7 @@ function handleVimKeys(key, state, screen) {
             renderScreen(state, screen);
         } else if (key === 'w') {
             const endOfWord = getCoorForwardWord(state);
-            copyToClipboard(state, [state.data[state.row].substring(state.col, endOfWord)], false);
+            copyToClipboard(state, [state.data[state.row].substring(state.col, endOfWord)]);
             state.data[state.row] = state.data[state.row].substring(0, state.col) + state.data[state.row].substring(endOfWord);
             state.mode = 'i';
             state.previousKeys = '';
@@ -524,20 +524,20 @@ function handleVimKeys(key, state, screen) {
     } else if (state.previousKeys === 'ci') {
         if (key === 'w') {
             const { beginning, end } = getCoorsInsideWord(state);
-            copyToClipboard(state, [state.data[state.row].substring(beginning + 1, end)], false);
+            copyToClipboard(state, [state.data[state.row].substring(beginning + 1, end)]);
             removeInsideAreaSameLine(state, beginning, end, 'i');
             logCommand(false, state, key);
             renderScreen(state, screen);
         } else if (key === 'f') {
             const { beginning, end } = getInsideOfIndentLevel(state);
             state.visualLine.row = beginning;
-        state.row = end;
-        state.col = 0;
-        const newClipboard = [];
-        for (let i = state.visualLine.row; i <= state.row; i += 1) {
-            newClipboard.push(state.data[i]);
-        }
-            copyToClipboard(state, newClipboard, true);
+            state.row = end;
+            state.col = 0;
+            const newClipboard = ['\n'];
+            for (let i = state.visualLine.row; i <= state.row; i += 1) {
+                newClipboard.push(state.data[i]);
+            }
+            copyToClipboard(state, newClipboard);
             state.data.splice(state.visualLine.row, state.row - state.visualLine.row + 1);
             state.row = state.visualLine.row;
             const indentLevel = state.data[state.row] !== undefined ? getIndentLevelFrom(state, state.row - 1) : 0;
@@ -548,31 +548,31 @@ function handleVimKeys(key, state, screen) {
             renderScreen(state, screen);
         } else if (key === '[' || key === ']' || key === 'd') {
             const { beginning, end } = getCoorsInsideCharDiff(state, '[', ']');
-            copyToClipboard(state, [state.data[state.row].substring(beginning + 1, end)], false);
+            copyToClipboard(state, [state.data[state.row].substring(beginning + 1, end)]);
             removeInsideAreaSameLine(state, beginning, end, 'i');
             logCommand(false, state, key);
             renderScreen(state, screen);
         } else if (key === '<' || key === '>' || key === 't') {
             const { beginning, end } = getCoorsInsideCharDiff(state, '<', '>');
-            copyToClipboard(state, [state.data[state.row].substring(beginning + 1, end)], false);
+            copyToClipboard(state, [state.data[state.row].substring(beginning + 1, end)]);
             removeInsideAreaSameLine(state, beginning, end, 'i');
             logCommand(false, state, key);
             renderScreen(state, screen);
         } else if (key === '(' || key === ')' || key === 'b') {
             const { beginning, end } = getCoorsInsideCharDiff(state, '(', ')');
-            copyToClipboard(state, [state.data[state.row].substring(beginning + 1, end)], false);
+            copyToClipboard(state, [state.data[state.row].substring(beginning + 1, end)]);
             removeInsideAreaSameLine(state, beginning, end, 'i');
             logCommand(false, state, key);
             renderScreen(state, screen);
         } else if (key === '{' || key === '}' || key === 'B') {
             const { beginning, end } = getCoorsInsideCharDiff(state, '{', '}');
-            copyToClipboard(state, [state.data[state.row].substring(beginning + 1, end)], false);
+            copyToClipboard(state, [state.data[state.row].substring(beginning + 1, end)]);
             removeInsideAreaSameLine(state, beginning, end, 'i');
             logCommand(false, state, key);
             renderScreen(state, screen);
         } else if (key === '\'' || key === '"' || key === '`') {
             const { beginning, end } = getCoorsInsideCharSame(state, key);
-            copyToClipboard(state, [state.data[state.row].substring(beginning + 1, end)], false);
+            copyToClipboard(state, [state.data[state.row].substring(beginning + 1, end)]);
             removeInsideAreaSameLine(state, beginning, end, 'i');
             logCommand(false, state, key);
             renderScreen(state, screen);
@@ -679,7 +679,7 @@ function handleVimKeys(key, state, screen) {
             renderScreen(state, screen);
         } else if (key === 'x') {
             if (state.col < state.data[state.row].length) {
-                copyToClipboard(state, [state.data[state.row].substring(state.col, state.col + 1)], false);
+                copyToClipboard(state, [state.data[state.row].substring(state.col, state.col + 1)]);
                 state.data[state.row] = state.data[state.row].substring(0, state.col)
                     + state.data[state.row].substring(state.col + 1);
             }
@@ -717,7 +717,7 @@ function handleVimKeys(key, state, screen) {
             logCommand(true, state, key);
             renderScreen(state, screen);
         } else if (key === 'Y') {
-            copyToClipboard(state, [state.data[state.row].substring(state.col)], false);
+            copyToClipboard(state, [state.data[state.row].substring(state.col)]);
             renderScreen(state, screen);
         } else if (key === 'C') {
             state.data[state.row] = state.data[state.row].substring(0, state.col);
@@ -725,7 +725,7 @@ function handleVimKeys(key, state, screen) {
             logCommand(true, state, key);
             renderScreen(state, screen);
         } else if (key === 'D') {
-            copyToClipboard(state, [state.data[state.row].substring(state.col)], false);
+            copyToClipboard(state, [state.data[state.row].substring(state.col)]);
             state.data[state.row] = state.data[state.row].substring(0, state.col);
             logCommand(true, state, key);
             createSnapshot(state);

--- a/src/keybinds/vimKeys.js
+++ b/src/keybinds/vimKeys.js
@@ -41,6 +41,7 @@ import {
     removeInsideAreaSameLine,
     copyInsideAreaSameLine,
     getIndentLevelFrom,
+    getInVisual,
     copyInVisual,
     deleteInVisual,
     setVisualHighlight,
@@ -904,8 +905,7 @@ function handleVimKeys(key, state, screen) {
         } else if (key === '*') {
             const { beginning, end } = getCoorsInsideWord(state);
             setVisualHighlight(state, beginning, end);
-            copyInVisual(state);
-            state.searchQuery = state.clipboard[0];
+            state.searchQuery = getInVisual(state);
             if (state.searchQuery !== '') {
                 state.col += state.searchQuery.length + 1;
                 searchForString(state, state.searchQuery);

--- a/src/keybinds/visualBlockKeys.js
+++ b/src/keybinds/visualBlockKeys.js
@@ -90,16 +90,6 @@ function handleVisualBlockKeys(key, state, screen) {
         state.col = 0;
     } else if (key === '^') {
         state.col = firstNonSpace(state, state.row);
-    } else if (key === '*') {
-        copyInVisualBlock(state);
-        state.searchQuery = state.clipboard[0];
-        state.mode = 'n';
-        if (state.searchQuery !== '') {
-            state.col += state.searchQuery.length + 1;
-            searchForString(state, state.searchQuery);
-            state.searching = true;
-            centerScreen(state);
-        }
     } else if (key === 'y') {
         copyInVisualBlock(state);
         if (state.row >= state.visualBlock.row) {

--- a/src/keybinds/visualKeys.js
+++ b/src/keybinds/visualKeys.js
@@ -122,10 +122,8 @@ function handleVisualKeys(key, state, screen) {
         if (systemPaste.startsWith('\n')) {
             systemPaste = systemPaste.substring(1);
         }
-        if (state.clipboard !== systemPaste.split('\n')) {
-            state.clipboard = systemPaste.split('\n');
-        }
-        if (state.clipboard.length > 0) {
+        systemPaste = systemPaste.split('\n');
+        if (systemPaste.length > 0) {
             if (state.row === state.visual.row) {
                 if (state.visual.col <= state.col) {
                     state.data[state.row] = state.data[state.row].substring(0, state.visual.col) + state.data[state.row].substring(state.col + 1);
@@ -143,10 +141,10 @@ function handleVisualKeys(key, state, screen) {
                 state.data.splice(state.row + 1, state.visual.row - state.row);
             }
             const cutoff = state.data[state.row].substring(state.col);
-            state.data[state.row] = state.data[state.row].substring(0, state.col) + state.clipboard[0];
+            state.data[state.row] = state.data[state.row].substring(0, state.col) + systemPaste[0];
             let counterRow = state.row;
-            for (let i = state.clipboard.length - 1; i >= 1; i -= 1) {
-                state.data.splice(state.row + 1, 0, state.clipboard[i]);
+            for (let i = systemPaste.length - 1; i >= 1; i -= 1) {
+                state.data.splice(state.row + 1, 0, systemPaste[i]);
                 counterRow += 1;
             }
             state.data[counterRow] += cutoff;

--- a/src/keybinds/visualKeys.js
+++ b/src/keybinds/visualKeys.js
@@ -119,9 +119,11 @@ function handleVisualKeys(key, state, screen) {
     } else if (key === '^') {
         state.col = firstNonSpace(state, state.row);
     } else if (key === 'p' || key === 'P') {
-        const systemPaste = ncp.paste().split('\n');
-        if (state.clipboard !== systemPaste) {
-            state.clipboard = systemPaste;
+        let systemPaste = ncp.paste();
+        let newLine = false;
+        if (systemPaste.startsWith('\n')) {
+            systemPaste = systemPaste.substring(1);
+            newLine = true;
         }
         if (state.clipboard.length > 0) {
             if (state.row === state.visual.row) {
@@ -140,7 +142,7 @@ function handleVisualKeys(key, state, screen) {
                 state.data[state.row] = state.data[state.row].substring(0, state.col) + state.data[state.visual.row].substring(state.visual.col + 1);
                 state.data.splice(state.row + 1, state.visual.row - state.row);
             }
-            if (state.clipboardNewLine) { //TODO fix
+            if (newLine) {
                 for (let i = state.clipboard.length - 1; i >= 0; i -= 1) {
                     state.data.splice(state.row, 0, state.clipboard[i]);
                 }

--- a/src/keybinds/visualKeys.js
+++ b/src/keybinds/visualKeys.js
@@ -35,7 +35,6 @@ import {
     increaseIndentLevel,
     decreaseIndentLevel,
     getIndentLevelFrom,
-    getIndentLevel,
     toForward,
     toBackward,
     isEmptyRow,
@@ -120,10 +119,8 @@ function handleVisualKeys(key, state, screen) {
         state.col = firstNonSpace(state, state.row);
     } else if (key === 'p' || key === 'P') {
         let systemPaste = ncp.paste();
-        let newLine = false;
         if (systemPaste.startsWith('\n')) {
             systemPaste = systemPaste.substring(1);
-            newLine = true;
         }
         if (state.clipboard !== systemPaste.split('\n')) {
             state.clipboard = systemPaste.split('\n');

--- a/src/keybinds/visualKeys.js
+++ b/src/keybinds/visualKeys.js
@@ -142,20 +142,14 @@ function handleVisualKeys(key, state, screen) {
                 state.data[state.row] = state.data[state.row].substring(0, state.col) + state.data[state.visual.row].substring(state.visual.col + 1);
                 state.data.splice(state.row + 1, state.visual.row - state.row);
             }
-            if (newLine) {
-                for (let i = state.clipboard.length - 1; i >= 0; i -= 1) {
-                    state.data.splice(state.row, 0, state.clipboard[i]);
-                }
-            } else {
-                const cutoff = state.data[state.row].substring(state.col);
-                state.data[state.row] = state.data[state.row].substring(0, state.col) + state.clipboard[0];
-                let counterRow = state.row;
-                for (let i = state.clipboard.length - 1; i >= 1; i -= 1) {
-                    state.data.splice(state.row + 1, 0, state.clipboard[i]);
-                    counterRow += 1;
-                }
-                state.data[counterRow] += cutoff;
+            const cutoff = state.data[state.row].substring(state.col);
+            state.data[state.row] = state.data[state.row].substring(0, state.col) + state.clipboard[0];
+            let counterRow = state.row;
+            for (let i = state.clipboard.length - 1; i >= 1; i -= 1) {
+                state.data.splice(state.row + 1, 0, state.clipboard[i]);
+                counterRow += 1;
             }
+            state.data[counterRow] += cutoff;
         }
         state.mode = 'n';
         createSnapshot(state);

--- a/src/keybinds/visualKeys.js
+++ b/src/keybinds/visualKeys.js
@@ -125,6 +125,9 @@ function handleVisualKeys(key, state, screen) {
             systemPaste = systemPaste.substring(1);
             newLine = true;
         }
+        if (state.clipboard !== systemPaste.split('\n')) {
+            state.clipboard = systemPaste.split('\n');
+        }
         if (state.clipboard.length > 0) {
             if (state.row === state.visual.row) {
                 if (state.visual.col <= state.col) {

--- a/src/keybinds/visualKeys.js
+++ b/src/keybinds/visualKeys.js
@@ -122,7 +122,6 @@ function handleVisualKeys(key, state, screen) {
         const systemPaste = ncp.paste().split('\n');
         if (state.clipboard !== systemPaste) {
             state.clipboard = systemPaste;
-            state.clipboardNewLine = false;
         }
         if (state.clipboard.length > 0) {
             if (state.row === state.visual.row) {
@@ -141,7 +140,7 @@ function handleVisualKeys(key, state, screen) {
                 state.data[state.row] = state.data[state.row].substring(0, state.col) + state.data[state.visual.row].substring(state.visual.col + 1);
                 state.data.splice(state.row + 1, state.visual.row - state.row);
             }
-            if (state.clipboardNewLine) {
+            if (state.clipboardNewLine) { //TODO fix
                 for (let i = state.clipboard.length - 1; i >= 0; i -= 1) {
                     state.data.splice(state.row, 0, state.clipboard[i]);
                 }

--- a/src/keybinds/visualLineKeys.js
+++ b/src/keybinds/visualLineKeys.js
@@ -65,18 +65,18 @@ function handleVisualLineKeys(key, state, screen) {
             down(state);
         } else if (key === 'y') {
             if (state.row >= state.visualLine.row) {
-                const newClipboard = [];
+                const newClipboard = ['\n'];
                 for (let i = state.visualLine.row; i <= state.row; i += 1) {
                     newClipboard.push(state.data[i]);
                 }
-                copyToClipboard(state, newClipboard, true);
+                copyToClipboard(state, newClipboard);
                 state.row = state.visualLine.row;
             } else if (state.row < state.visualLine.row) {
-                const newClipboard = [];
+                const newClipboard = ['\n'];
                 for (let i = state.row; i <= state.visualLine.row; i += 1) {
                     newClipboard.push(state.data[i]);
                 }
-                copyToClipboard(state, newClipboard, true);
+                copyToClipboard(state, newClipboard);
             }
             state.mode = 'n';
         } else if (key === 'c') {
@@ -128,19 +128,19 @@ function handleVisualLineKeys(key, state, screen) {
                 state.previousKeys = '';
             } else {
                 if (state.row >= state.visualLine.row) {
-                    const newClipboard = [];
+                    const newClipboard = ['\n'];
                     for (let i = state.visualLine.row; i <= state.row; i += 1) {
                         newClipboard.push(state.data[i]);
                     }
-                    copyToClipboard(state, newClipboard, true);
+                    copyToClipboard(state, newClipboard);
                     state.data.splice(state.visualLine.row, state.row - state.visualLine.row + 1);
                     state.row = state.visualLine.row;
                 } else if (state.row < state.visualLine.row) {
-                    const newClipboard = [];
+                    const newClipboard = ['\n'];
                     for (let i = state.row; i <= state.visualLine.row; i += 1) {
                         newClipboard.push(state.data[i]);
                     }
-                    copyToClipboard(state, newClipboard, true);
+                    copyToClipboard(state, newClipboard);
                     state.data.splice(state.row, state.visualLine.row - state.row + 1);
                 }
                 const indentLevel = state.data[state.row] !== undefined ? getIndentLevelFrom(state, state.row) : 0;
@@ -150,19 +150,19 @@ function handleVisualLineKeys(key, state, screen) {
             }
         } else if (key === 'd') {
             if (state.row >= state.visualLine.row) {
-                const newClipboard = [];
+                const newClipboard = ['\n'];
                 for (let i = state.visualLine.row; i <= state.row; i += 1) {
                     newClipboard.push(state.data[i]);
                 }
-                copyToClipboard(state, newClipboard, true);
+                copyToClipboard(state, newClipboard);
                 state.data.splice(state.visualLine.row, state.row - state.visualLine.row + 1);
                 state.row = state.visualLine.row;
             } else if (state.row < state.visualLine.row) {
-                const newClipboard = [];
+                const newClipboard = ['\n'];
                 for (let i = state.row; i <= state.visualLine.row; i += 1) {
                     newClipboard.push(state.data[i]);
                 }
-                copyToClipboard(state, newClipboard, true);
+                copyToClipboard(state, newClipboard);
                 state.data.splice(state.row, state.visualLine.row - state.row + 1);
             }
             if (state.row > state.data.length - 1) {
@@ -281,7 +281,6 @@ function handleVisualLineKeys(key, state, screen) {
             const systemPaste = ncp.paste().split('\n');
             if (state.clipboard !== systemPaste) {
                 state.clipboard = systemPaste;
-                state.clipboardNewLine = true;
             }
             if (state.clipboard.length > 0) {
                 if (state.row >= state.visualLine.row) {

--- a/src/keybinds/visualLineKeys.js
+++ b/src/keybinds/visualLineKeys.js
@@ -279,10 +279,8 @@ function handleVisualLineKeys(key, state, screen) {
             createSnapshot(state);
         } else if (key === 'p' || key === 'P') {
             let systemPaste = ncp.paste();
-            let newLine = false;
             if (systemPaste.startsWith('\n')) {
                 systemPaste = systemPaste.substring(1);
-                newLine = true;
             }
             if (state.clipboard !== systemPaste.split('\n')) {
                 state.clipboard = systemPaste.split('\n');

--- a/src/keybinds/visualLineKeys.js
+++ b/src/keybinds/visualLineKeys.js
@@ -282,18 +282,16 @@ function handleVisualLineKeys(key, state, screen) {
             if (systemPaste.startsWith('\n')) {
                 systemPaste = systemPaste.substring(1);
             }
-            if (state.clipboard !== systemPaste.split('\n')) {
-                state.clipboard = systemPaste.split('\n');
-            }
-            if (state.clipboard.length > 0) {
+            systemPaste = systemPaste.split('\n');
+            if (systemPaste.length > 0) {
                 if (state.row >= state.visualLine.row) {
                     state.data.splice(state.visualLine.row, state.row - state.visualLine.row + 1);
                     state.row = state.visualLine.row;
                 } else if (state.row < state.visualLine.row) {
                     state.data.splice(state.row, state.visualLine.row - state.row + 1);
                 }
-                for (let i = state.clipboard.length - 1; i >= 0; i -= 1) {
-                    state.data.splice(state.row, 0, state.clipboard[i]);
+                for (let i = systemPaste.length - 1; i >= 0; i -= 1) {
+                    state.data.splice(state.row, 0, systemPaste[i]);
                 }
             }
             state.mode = 'n';

--- a/src/keybinds/visualLineKeys.js
+++ b/src/keybinds/visualLineKeys.js
@@ -278,9 +278,14 @@ function handleVisualLineKeys(key, state, screen) {
             state.mode = 'n';
             createSnapshot(state);
         } else if (key === 'p' || key === 'P') {
-            const systemPaste = ncp.paste().split('\n');
-            if (state.clipboard !== systemPaste) {
-                state.clipboard = systemPaste;
+            let systemPaste = ncp.paste();
+            let newLine = false;
+            if (systemPaste.startsWith('\n')) {
+                systemPaste = systemPaste.substring(1);
+                newLine = true;
+            }
+            if (state.clipboard !== systemPaste.split('\n')) {
+                state.clipboard = systemPaste.split('\n');
             }
             if (state.clipboard.length > 0) {
                 if (state.row >= state.visualLine.row) {
@@ -289,7 +294,7 @@ function handleVisualLineKeys(key, state, screen) {
                 } else if (state.row < state.visualLine.row) {
                     state.data.splice(state.row, state.visualLine.row - state.row + 1);
                 }
-                if (state.clipboardNewLine) {
+                if (newLine) {
                     for (let i = state.clipboard.length - 1; i >= 0; i -= 1) {
                         state.data.splice(state.row, 0, state.clipboard[i]);
                     }

--- a/src/keybinds/visualLineKeys.js
+++ b/src/keybinds/visualLineKeys.js
@@ -294,19 +294,8 @@ function handleVisualLineKeys(key, state, screen) {
                 } else if (state.row < state.visualLine.row) {
                     state.data.splice(state.row, state.visualLine.row - state.row + 1);
                 }
-                if (newLine) {
-                    for (let i = state.clipboard.length - 1; i >= 0; i -= 1) {
-                        state.data.splice(state.row, 0, state.clipboard[i]);
-                    }
-                } else {
-                    const cutoff = state.data[state.row].substring(state.col);
-                    state.data[state.row] = state.data[state.row].substring(0, state.col) + state.clipboard[0];
-                    let counterRow = state.row;
-                    for (let i = state.clipboard.length - 1; i >= 1; i -= 1) {
-                        state.data.splice(state.row + 1, 0, state.clipboard[i]);
-                        counterRow += 1;
-                    }
-                    state.data[counterRow] += cutoff;
+                for (let i = state.clipboard.length - 1; i >= 0; i -= 1) {
+                    state.data.splice(state.row, 0, state.clipboard[i]);
                 }
             }
             state.mode = 'n';

--- a/src/util/helper.js
+++ b/src/util/helper.js
@@ -48,6 +48,9 @@ function pasteFromClipboardAfter(state) {
         systemPaste = systemPaste.substring(1);
         newLine = true;
     }
+    if (state.clipboard !== systemPaste.split('\n')) {
+        state.clipboard = systemPaste.split('\n');
+    }
     if (state.clipboard.length > 0) {
         if (newLine) {
             for (let i = state.clipboard.length - 1; i > 0; i -= 1) {

--- a/src/util/helper.js
+++ b/src/util/helper.js
@@ -12,13 +12,18 @@ function getData(filepath) {
 }
 
 function pasteFromClipboardBefore(state) {
-    const systemPaste = ncp.paste().split('\n');
-    if (state.clipboard !== systemPaste) {
-        state.clipboard = systemPaste;
+    let systemPaste = ncp.paste();
+    let newLine = false;
+    if (systemPaste.startsWith('\n')) {
+        systemPaste = systemPaste.substring(1);
+        newLine = true;
+    }
+    if (state.clipboard !== systemPaste.split('\n')) {
+        state.clipboard = systemPaste.split('\n');
     }
     if (state.clipboard.length > 0) {
-        if (state.clipboardNewLine) {
-            for (let i = state.clipboard.length - 1; i >= 0; i -= 1) {
+        if (newLine) {
+            for (let i = state.clipboard.length - 1; i > 0; i -= 1) {
                 state.data.splice(state.row, 0, state.clipboard[i]);
             }
         } else {
@@ -37,13 +42,15 @@ function pasteFromClipboardBefore(state) {
 }
 
 function pasteFromClipboardAfter(state) {
-    const systemPaste = ncp.paste().split('\n');
-    if (state.clipboard !== systemPaste) {
-        state.clipboard = systemPaste;
+    let systemPaste = ncp.paste();
+    let newLine = false;
+    if (systemPaste.startsWith('\n')) {
+        systemPaste = systemPaste.substring(1);
+        newLine = true;
     }
     if (state.clipboard.length > 0) {
-        if (state.clipboardNewLine) {
-            for (let i = state.clipboard.length - 1; i >= 0; i -= 1) {
+        if (newLine) {
+            for (let i = state.clipboard.length - 1; i > 0; i -= 1) {
                 state.data.splice(state.row + 1, 0, state.clipboard[i]);
             }
         } else {
@@ -361,9 +368,8 @@ function getColorRow(replacing, replaceQuery, row, commentIndex, searching, sear
     return output;
 }
 
-function copyToClipboard(state, textArray, newLine, clipboardVisualBlock) {
+function copyToClipboard(state, textArray, clipboardVisualBlock) {
     state.clipboard = textArray;
-    state.clipboardNewLine = newLine;
     state.clipboardVisualBlock = clipboardVisualBlock;
     ncp.copy(state.clipboard.join('\n'));
 }

--- a/src/util/helper.js
+++ b/src/util/helper.js
@@ -18,20 +18,18 @@ function pasteFromClipboardBefore(state) {
         systemPaste = systemPaste.substring(1);
         newLine = true;
     }
-    if (state.clipboard !== systemPaste.split('\n')) {
-        state.clipboard = systemPaste.split('\n');
-    }
-    if (state.clipboard.length > 0) {
+    systemPaste = systemPaste.split('\n');
+    if (systemPaste.length > 0) {
         if (newLine) {
-            for (let i = state.clipboard.length - 1; i > 0; i -= 1) {
-                state.data.splice(state.row, 0, state.clipboard[i]);
+            for (let i = systemPaste.length - 1; i > 0; i -= 1) {
+                state.data.splice(state.row, 0, systemPaste[i]);
             }
         } else {
             const cutoff = state.data[state.row].substring(state.col);
-            state.data[state.row] = state.data[state.row].substring(0, state.col) + state.clipboard[0];
+            state.data[state.row] = state.data[state.row].substring(0, state.col) + systemPaste[0];
             let counterRow = state.row;
-            for (let i = state.clipboard.length - 1; i >= 1; i -= 1) {
-                state.data.splice(state.row + 1, 0, state.clipboard[i]);
+            for (let i = systemPaste.length - 1; i >= 1; i -= 1) {
+                state.data.splice(state.row + 1, 0, systemPaste[i]);
                 counterRow += 1;
             }
             state.data[counterRow] += cutoff;
@@ -48,20 +46,18 @@ function pasteFromClipboardAfter(state) {
         systemPaste = systemPaste.substring(1);
         newLine = true;
     }
-    if (state.clipboard !== systemPaste.split('\n')) {
-        state.clipboard = systemPaste.split('\n');
-    }
-    if (state.clipboard.length > 0) {
+    systemPaste = systemPaste.split('\n');
+    if (systemPaste.length > 0) {
         if (newLine) {
-            for (let i = state.clipboard.length - 1; i > 0; i -= 1) {
-                state.data.splice(state.row + 1, 0, state.clipboard[i]);
+            for (let i = systemPaste.length - 1; i > 0; i -= 1) {
+                state.data.splice(state.row + 1, 0, systemPaste[i]);
             }
         } else {
             const cutoff = state.data[state.row].substring(state.col + 1);
-            state.data[state.row] = state.data[state.row].substring(0, state.col + 1) + state.clipboard[0];
+            state.data[state.row] = state.data[state.row].substring(0, state.col + 1) + systemPaste[0];
             let counterRow = state.row;
-            for (let i = state.clipboard.length - 1; i >= 1; i -= 1) {
-                state.data.splice(state.row + 1, 0, state.clipboard[i]);
+            for (let i = systemPaste.length - 1; i >= 1; i -= 1) {
+                state.data.splice(state.row + 1, 0, systemPaste[i]);
                 counterRow += 1;
             }
             state.data[counterRow] += cutoff;
@@ -372,9 +368,8 @@ function getColorRow(replacing, replaceQuery, row, commentIndex, searching, sear
 }
 
 function copyToClipboard(state, textArray, clipboardVisualBlock) {
-    state.clipboard = textArray;
     state.clipboardVisualBlock = clipboardVisualBlock;
-    ncp.copy(state.clipboard.join('\n'));
+    ncp.copy(textArray.join('\n'));
 }
 
 async function saveFile(state) {

--- a/src/util/movement.js
+++ b/src/util/movement.js
@@ -651,7 +651,7 @@ function copyInVisualBlock(state) {
             newClipboard.push(state.data[i] = state.data[i].substring(state.col, state.visualBlock.col + 1));
         }
     }
-    copyToClipboard(state, newClipboard);
+    copyToClipboard(state, newClipboard, true);
 }
 
 function deleteInVisualBlock(state) {
@@ -709,7 +709,7 @@ function copyInVisual(state) {
             copyToClipboard(state, [state.data[state.row].substring(state.col, state.visual.col + 1)]);
         }
     } else if (state.row > state.visual.row) {
-        const newClipboard = ['\n'];
+        const newClipboard = [];
         newClipboard.push(state.data[state.visual.row].substring(state.visual.col));
         for (let i = state.visual.row + 1; i < state.row; i += 1) {
             newClipboard.push(state.data[i]);
@@ -717,7 +717,7 @@ function copyInVisual(state) {
         newClipboard.push(state.data[state.row].substring(0, state.col + 1));
         copyToClipboard(state, newClipboard);
     } else if (state.row < state.visual.row) {
-        const newClipboard = ['\n'];
+        const newClipboard = [];
         newClipboard.push(state.data[state.row].substring(state.col));
         for (let i = state.row + 1; i < state.visual.row; i += 1) {
             newClipboard.push(state.data[i]);

--- a/src/util/movement.js
+++ b/src/util/movement.js
@@ -35,7 +35,7 @@ function previousSameIndentLevel(state, row) {
 }
 
 function getInsideOfIndentLevel(state) {
-    let currentIndent = getIndentLevel(state, state.row);
+    const currentIndent = getIndentLevel(state, state.row);
     let beginning = state.row;
     let end = state.row;
     for (let i = state.row - 1; i >= 0; i -= 1) {

--- a/src/util/movement.js
+++ b/src/util/movement.js
@@ -615,7 +615,7 @@ function endOfLine(state, row) {
 
 function copyInsideAreaSameLine(state, beginning, end) {
     if (beginning !== end && beginning !== -1 && end !== -1) {
-        copyToClipboard(state, [state.data[state.row].substring(beginning + 1, end)], false);
+        copyToClipboard(state, [state.data[state.row].substring(beginning + 1, end)]);
         state.col = beginning + 1;
     }
 }
@@ -643,7 +643,7 @@ function setVisualBlockHighlight(state, beginning, end) {
 }
 
 function copyInVisualBlock(state) {
-    const newClipboard = [];
+    const newClipboard = ['\n'];
     for (let i = Math.min(state.row, state.visualBlock.row); i < Math.max(state.row, state.visualBlock.row) + 1; i += 1) {
         if (state.visualBlock.col <= state.col) {
             newClipboard.push(state.data[i].substring(state.visualBlock.col, state.col + 1));
@@ -651,7 +651,7 @@ function copyInVisualBlock(state) {
             newClipboard.push(state.data[i] = state.data[i].substring(state.col, state.visualBlock.col + 1));
         }
     }
-    copyToClipboard(state, newClipboard, false, true);
+    copyToClipboard(state, newClipboard);
 }
 
 function deleteInVisualBlock(state) {
@@ -704,26 +704,26 @@ function getInVisual(state) {
 function copyInVisual(state) {
     if (state.row === state.visual.row) {
         if (state.visual.col <= state.col) {
-            copyToClipboard(state, [state.data[state.row].substring(state.visual.col, state.col + 1)], false);
+            copyToClipboard(state, [state.data[state.row].substring(state.visual.col, state.col + 1)]);
         } else if (state.visual.col > state.col) {
-            copyToClipboard(state, [state.data[state.row].substring(state.col, state.visual.col + 1)], false);
+            copyToClipboard(state, [state.data[state.row].substring(state.col, state.visual.col + 1)]);
         }
     } else if (state.row > state.visual.row) {
-        const newClipboard = [];
+        const newClipboard = ['\n'];
         newClipboard.push(state.data[state.visual.row].substring(state.visual.col));
         for (let i = state.visual.row + 1; i < state.row; i += 1) {
             newClipboard.push(state.data[i]);
         }
         newClipboard.push(state.data[state.row].substring(0, state.col + 1));
-        copyToClipboard(state, newClipboard, false);
+        copyToClipboard(state, newClipboard);
     } else if (state.row < state.visual.row) {
-        const newClipboard = [];
+        const newClipboard = ['\n'];
         newClipboard.push(state.data[state.row].substring(state.col));
         for (let i = state.row + 1; i < state.visual.row; i += 1) {
             newClipboard.push(state.data[i]);
         }
         newClipboard.push(state.data[state.visual.row].substring(0, state.visual.col + 1));
-        copyToClipboard(state, newClipboard, false);
+        copyToClipboard(state, newClipboard);
     }
 }
 


### PR DESCRIPTION
## problem
clipboard doesn't use standard of having '\n' in front for pasting entire lines
## solution
fix that to put '\n' in front when we are copying entire lines instead of just text from visual mode